### PR TITLE
Fix not `$reload` on `getTranslations`

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -60,7 +60,7 @@ class Manager
      */
     public function getTranslations($reload = false)
     {
-        if ($this->translations && $reload) {
+        if ($this->translations && !$reload) {
             return $this->translations;
         }
 


### PR DESCRIPTION
I think it should not return the cached translations when `$reload` is `true`