### PR TITLE
move functions to config

### DIFF
--- a/config/langmanGUI.php
+++ b/config/langmanGUI.php
@@ -2,7 +2,7 @@
 
 return [
     'base_language' => 'en',
-
+    'functions' => ['__'],
     'route_group_config' => [
         'middleware' => ['web'],
         'namespace' => 'Themsaid\LangmanGUI'

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -130,7 +130,7 @@ class Manager
          *
          * https://github.com/barryvdh/laravel-translation-manager/blob/master/src/Manager.php
          */
-        $functions = ['__'];
+        $functions = config('langmanGUI.functions', ['__']);
 
         $pattern =
             // See https://regex101.com/r/jS5fX0/3

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -136,6 +136,7 @@ class Manager
             // See https://regex101.com/r/jS5fX0/3
             '[^\w]'. // Must not start with any alphanum or _
             '(?<!->)'. // Must not start with ->
+            '(?<!(function ))'. // Must not start with 'function '
             '('.implode('|', $functions).')'.// Must start with one of the functions
             "\(".// Match opening parentheses
             "[\'\"]".// Match " or '


### PR DESCRIPTION
We use other multiple functions for translating texts, so the scanner does not pick these up, moving this to config will enable us to do so.