### PR TITLE
Array translations

### DIFF
--- a/public/langman.js
+++ b/public/langman.js
@@ -43405,12 +43405,10 @@ new Vue({
         scanForKeys() {
             $.post('/langman/scan', {_token: langman.csrf})
                 .done(response => {
-                    if (response.length) {
-                        _.forEach(response, key => {
-                            this.addNewKey(key);
-                        });
+                    if (typeof response === 'object') {
 
-                        this.addValuesToBaseLanguage();
+                        console.log(response);
+                        Object.assign(this.translations, response);
 
                         return alert('Langman searched your files & found new keys to translate.');
                     }
@@ -43435,8 +43433,9 @@ new Vue({
 
     watch: {
         translations:  {
-            handler: function() {
+            handler: function(translations) {
                 this.hasChanges = true;
+                this.files = Object.keys(translations[this.selectedLanguage]);
             },
             deep: true
         },
@@ -43450,6 +43449,11 @@ new Vue({
             else {
                 window.onbeforeunload = null;
             }
+        },
+
+        selectedLanguage: function(language) {
+            this.files = Object.keys(this.translations[language]);
+            this.selectedFile = this.files[0];
         }
     }
 });

--- a/public/langman.js
+++ b/public/langman.js
@@ -43454,6 +43454,11 @@ new Vue({
         selectedLanguage: function(language) {
             this.files = Object.keys(this.translations[language]);
             this.selectedFile = this.files[0];
+        },
+
+        selectedKey: function(key)
+        {
+            this.selectedKey = String(key);
         }
     }
 });

--- a/public/langman.js
+++ b/public/langman.js
@@ -43344,8 +43344,6 @@ new Vue({
 
                 this.$set(this.translations[lang][this.selectedFile], key, '');
             });
-
-            this.addValuesToBaseLanguage();
         },
 
 

--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -152,12 +152,10 @@ new Vue({
         scanForKeys() {
             $.post('/langman/scan', {_token: langman.csrf})
                 .done(response => {
-                    if (response.length) {
-                        _.forEach(response, key => {
-                            this.addNewKey(key);
-                        });
+                    if (typeof response === 'object') {
 
-                        this.addValuesToBaseLanguage();
+                        console.log(response);
+                        Object.assign(this.translations, response);
 
                         return alert('Langman searched your files & found new keys to translate.');
                     }
@@ -182,8 +180,9 @@ new Vue({
 
     watch: {
         translations:  {
-            handler: function() {
+            handler: function(translations) {
                 this.hasChanges = true;
+                this.files = Object.keys(translations[this.selectedLanguage]);
             },
             deep: true
         },
@@ -197,6 +196,11 @@ new Vue({
             else {
                 window.onbeforeunload = null;
             }
+        },
+
+        selectedLanguage: function(language) {
+            this.files = Object.keys(this.translations[language]);
+            this.selectedFile = this.files[0];
         }
     }
 });

--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -164,20 +164,15 @@ new Vue({
                 })
         },
 
-
         /**
-         * Ask the user for confirmation before leaving if changes exist.
          */
-        confirmBeforeLeavingWithChanges(objectToWatch) {
-            this.$watch(objectToWatch, function () {
-                this.hasChanges = true;
 
-                if (!window.onbeforeunload) {
-                    window.onbeforeunload = function () {
-                        return 'Are you sure you want to leave?';
-                    };
-                }
-            }, {deep: true});
+    watch: {
+        translations:  {
+            handler: function() {
+                this.hasChanges = true;
+            },
+            deep: true
         },
 
 
@@ -190,6 +185,15 @@ new Vue({
                     this.translations[this.baseLanguage][key] = key;
                 }
             });
+        hasChanges: function() {
+            if(this.hasChanges) {
+                window.onbeforeunload = function () {
+                    return 'Are you sure you want to leave?';
+                };
+            }
+            else {
+                window.onbeforeunload = null;
+            }
         }
     }
 });

--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -201,6 +201,11 @@ new Vue({
         selectedLanguage: function(language) {
             this.files = Object.keys(this.translations[language]);
             this.selectedFile = this.files[0];
+        },
+
+        selectedKey: function(key)
+        {
+            this.selectedKey = String(key);
         }
     }
 });

--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -91,8 +91,6 @@ new Vue({
 
                 this.$set(this.translations[lang][this.selectedFile], key, '');
             });
-
-            this.addValuesToBaseLanguage();
         },
 
 

--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -8,7 +8,9 @@ new Vue({
             searchPhrase: '',
             baseLanguage: langman.baseLanguage,
             selectedLanguage: langman.baseLanguage,
+            selectedFile: Object.keys(langman.translations[langman.baseLanguage])[0],
             languages: langman.languages,
+            files: Object.keys(langman.translations[langman.baseLanguage]),
             translations: langman.translations,
             selectedKey: null,
             hasChanges: false
@@ -20,8 +22,6 @@ new Vue({
      */
     mounted() {
         this.addValuesToBaseLanguage();
-
-        this.confirmBeforeLeavingWithChanges('translations');
     },
 
     computed: {
@@ -46,7 +46,7 @@ new Vue({
          * List of translation lines from the current language.
          */
         currentLanguageTranslations() {
-            return _.map(this.translations[this.selectedLanguage], (value, key) => {
+            return _.map(this.translations[this.selectedLanguage][this.selectedFile], (value, key) => {
                 return {key: key, value: value ? value : ''};
             });
         },
@@ -56,7 +56,7 @@ new Vue({
          * List of untranslated keys from the current language.
          */
         currentLanguageUntranslatedKeys() {
-            return _.filter(this.translations[this.selectedLanguage], value => {
+            return _.filter(this.translations[this.selectedLanguage][this.selectedFile], value => {
                 return !value;
             });
         }
@@ -80,16 +80,16 @@ new Vue({
          * Add a new translation key
          */
         addNewKey(key) {
-            if (this.translations[this.baseLanguage][key] !== undefined) {
+            if (this.translations[this.baseLanguage][this.selectedFile][key] !== undefined) {
                 return alert('This key already exists.');
             }
 
             _.forEach(this.languages, lang => {
-                if (!this.translations[lang]) {
-                    this.translations[lang] = {};
+                if (!this.translations[lang][this.selectedFile]) {
+                    this.translations[lang][this.selectedFile] = {};
                 }
 
-                this.$set(this.translations[lang], key, '');
+                this.$set(this.translations[lang][this.selectedFile], key, '');
             });
 
             this.addValuesToBaseLanguage();
@@ -102,7 +102,9 @@ new Vue({
         removeKey(key) {
             if (confirm('Are you sure you want to remove "' + key + '"')) {
                 _.forEach(this.languages, lang => {
-                    this.translations[lang] = _.omit(this.translations[lang], [key]);
+                    _.forEach(this.files, file => {
+                        this.translations[lang][file] = _.omit(this.translations[lang][file], [key]);
+                    });
                 });
 
                 this.selectedKey = null;
@@ -134,11 +136,13 @@ new Vue({
          * Save the translation lines.
          */
         save() {
+            var self = this;
             $.ajax('/langman/save', {
                 data: JSON.stringify({translations: this.translations}),
                 headers: {"X-CSRF-TOKEN": langman.csrf},
                 type: 'POST', contentType: 'application/json'
             }).done(function () {
+                self.hasChanges = false;
                 alert('Saved Successfully.');
             })
         },
@@ -165,7 +169,18 @@ new Vue({
         },
 
         /**
+         * Add values to the base language used.
          */
+        addValuesToBaseLanguage() {
+            _.forEach(this.files, file => {
+                _.forEach(this.translations[this.baseLanguage][file], (value, key) => {
+                    if (!value) {
+                        this.translations[this.baseLanguage][file][key] = key;
+                    }
+                });
+            });            
+        }
+    },
 
     watch: {
         translations:  {
@@ -175,16 +190,6 @@ new Vue({
             deep: true
         },
 
-
-        /**
-         * Add values to the base language used.
-         */
-        addValuesToBaseLanguage() {
-            _.forEach(this.translations[this.baseLanguage], (value, key) => {
-                if (!value) {
-                    this.translations[this.baseLanguage][key] = key;
-                }
-            });
         hasChanges: function() {
             if(this.hasChanges) {
                 window.onbeforeunload = function () {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -98,13 +98,19 @@
                         @{{ selectedKey }}
                     </p>
 
-                <textarea name="" rows="10" class="form-control mb-4"
-                          v-model="translations[selectedLanguage][selectedKey]"
+                    <textarea name="" rows="10" class="form-control mb-4" v-if="typeof translations[selectedLanguage][selectedFile][selectedKey] !== 'object'"
+                          v-model="translations[selectedLanguage][selectedFile][selectedKey]"
                           placeholder="Translate..."></textarea>
+
+                    <textarea name="" rows="10" class="form-control mb-4" v-if="typeof translations[selectedLanguage][selectedFile][selectedKey] === 'object'"
+                          v-for="(line, index) in translations[selectedLanguage][selectedFile][selectedKey]"
+                          v-model="translations[selectedLanguage][selectedFile][selectedKey][index]"
+                          placeholder="Translate...">@{{ line }}</textarea>
 
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-outline-danger btn-sm" v-on:click="removeKey(selectedKey)">Delete this key</button>
                     </div>
+
                 </div>
 
                 <h5 class="text-muted text-center" v-else>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -8,75 +8,98 @@
     <title>Langman</title>
 
     <!-- Style sheets-->
-    <link href='{{asset('vendor/langman/langman.css')}}' rel='stylesheet' type='text/css'>
+    <link href='{{ asset('vendor/langman/langman.css') }}' rel='stylesheet' type='text/css'>
 
     <!-- Icons -->
     <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
 </head>
 <body>
+
 <div id="app" v-cloak>
 
     <nav class="navbar navbar-toggleable-md navbar-light mb-4">
+
         <div class="container">
 
             <ul class="navbar-nav mr-auto">
+
                 <li class="nav-item active">
                     <span class="navbar-text">@{{ _.toArray(currentLanguageTranslations).length }} Keys</span>
                 </li>
+
                 <li class="nav-item active ml-3" v-if="_.toArray(currentLanguageUntranslatedKeys).length">
                     <span class="navbar-text text-danger">@{{ _.toArray(currentLanguageUntranslatedKeys).length }} Un-translated</span>
                 </li>
+
             </ul>
 
             <ul class="navbar-nav ml-auto mr-3">
+
                 <li class="nav-item dropdown">
+
                     <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         @{{ selectedLanguage }}
                     </a>
+
                     <div class="dropdown-menu dropdown-menu-right">
                         <a v-for="lang in languages"
                            href="#" role="button"
                            v-on:click="selectedLanguage = lang"
                            class="dropdown-item" href="#">@{{ lang }}</a>
                     </div>
+
                 </li>
+
                 <li class="nav-item dropdown">
+
                     <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         @{{ selectedFile }}
                     </a>
+
                     <div class="dropdown-menu dropdown-menu-right">
                         <a v-for="file in files"
                            href="#" role="button"
                            v-on:click="selectedFile = file"
                            class="dropdown-item" href="#">@{{ file }}</a>
                     </div>
+
                 </li>
+
             </ul>
+
             <button class="btn btn-outline-info btn-sm mr-2"
                     v-on:click="promptToAddNewKey" v-if="languages.length"
                     type="button">Add
             </button>
+
             <button class="btn btn-outline-info btn-sm mr-2"
                     v-on:click="scanForKeys" v-if="languages.length"
                     type="button">Scan
             </button>
+
             <button class="btn btn-outline-success btn-sm"
                     v-on:click="save" v-if="languages.length"
                     type="button">Save
                 <small v-if="this.hasChanges" class="text-danger">&#9679;</small>
             </button>
+
         </div>
+
     </nav>
 
     <div class="container">
+
         <div class="row" v-if="baseLanguage && _.toArray(currentLanguageTranslations).length">
+
             <div class="col">
+
                 <div class="input-group mainSearch">
                     <div class="input-group-addon"><i class="fa fa-search"></i></div>
                     <input type="text" class="form-control" v-model="searchPhrase" placeholder="Search">
                 </div>
 
                 <div class="mt-4" style="overflow: scroll; height: 500px">
+
                     <div class="list-group">
 
                         <a href="#" role="button"
@@ -90,22 +113,29 @@
                         </a>
 
                     </div>
+
                 </div>
+
             </div>
+
             <div class="col">
+
                 <div v-if="selectedKey">
+
                     <p class="mb-4">
                         @{{ selectedKey }}
                     </p>
 
                     <textarea name="" rows="10" class="form-control mb-4" v-if="typeof translations[selectedLanguage][selectedFile][selectedKey] !== 'object'"
                           v-model="translations[selectedLanguage][selectedFile][selectedKey]"
-                          placeholder="Translate..."></textarea>
+                          placeholder="Translate...">
+                    </textarea>
 
                     <textarea name="" rows="10" class="form-control mb-4" v-if="typeof translations[selectedLanguage][selectedFile][selectedKey] === 'object'"
                           v-for="(line, index) in translations[selectedLanguage][selectedFile][selectedKey]"
                           v-model="translations[selectedLanguage][selectedFile][selectedKey][index]"
-                          placeholder="Translate...">@{{ line }}</textarea>
+                          placeholder="Translate...">
+                    </textarea>
 
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-outline-danger btn-sm" v-on:click="removeKey(selectedKey)">Delete this key</button>
@@ -119,21 +149,27 @@
                     .<br><br>
                     Select a key from the list to the left
                 </h5>
+
             </div>
+
         </div>
 
         <div v-else>
+
             <p class="lead text-center" v-if="!languages.length">
-                There are no JSON language files in your project.<br>
+                There are no language files in your project.<br>
                 <button class="btn btn-outline-primary mt-3" v-on:click="addLanguage">Add Language</button>
             </p>
 
             <p class="lead text-center" v-if="languages.length">
-                There are no Translation lines yet, start by adding new keys or <br>
+                There are no translation lines yet, start by adding new keys or <br>
                 <a href="#" role="button" v-on:click="scanForKeys">scan</a> your project for lines to translate.
             </p>
+
         </div>
+
     </div>
+
 </div>
 
 <script>
@@ -144,6 +180,6 @@
         translations: {!! json_encode($translations) !!}
     };
 </script>
-<script src="{{asset('vendor/langman/langman.js')}}"></script>
+<script src="{{ asset('vendor/langman/langman.js') }}"></script>
 </body>
 </html>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -40,6 +40,17 @@
                            class="dropdown-item" href="#">@{{ lang }}</a>
                     </div>
                 </li>
+                <li class="nav-item dropdown">
+                    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        @{{ selectedFile }}
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-right">
+                        <a v-for="file in files"
+                           href="#" role="button"
+                           v-on:click="selectedFile = file"
+                           class="dropdown-item" href="#">@{{ file }}</a>
+                    </div>
+                </li>
             </ul>
             <button class="btn btn-outline-info btn-sm mr-2"
                     v-on:click="promptToAddNewKey" v-if="languages.length"

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -156,16 +156,16 @@ class Manager
 
         $pattern =
             // See https://regex101.com/r/jS5fX0/5
-            '[^\w]'. // Must not start with any alphanum or _
-            '(?<!->)'. // Must not start with ->
-            '('.implode('|', $functions).')'.// Must start with one of the functions
-            "\(".// Match opening parentheses
-            "[\'\"]".// Match " or '
-            '('.// Start a new group to match:
-            '.+'.// Must start with group
-            ')'.// Close group
-            "[\'\"]".// Closing quote
-            "[\),]"  // Close parentheses or new parameter
+            '[^\w]' . // Must not start with any alphanum or _
+            '(?<!->)' . // Must not start with ->
+            '(' . implode('|', $functions) . ')' .// Must start with one of the functions
+            "\(\s?" .// Match opening parentheses with optional space character
+            "[\'\"]" .// Match " or '
+            '(' .// Start a new group to match:
+            '.+' .// Must start with group
+            ')' .// Close group
+            "[\'\"]?" .// Closing quote
+            "[\s\),]"  // Close parentheses optional space character or new parameter
         ;
 
         $allMatches = [];
@@ -191,6 +191,8 @@ class Manager
         }
 
         $this->disk->copyDirectory(resource_path('lang'), storage_path('langmanGUI/'.time()));
+    }
+
     public function getJsonTranslations()
     {
         collect($this->disk->allFiles($this->languageFilesPath))

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -89,12 +89,30 @@ class Manager
         return $this->translations;
     }
 
-        $keysFromFiles = array_collapse($this->getTranslationsFromFiles());
+    private function syncStringKeys($stringKeys)
+    {
+        foreach($stringKeys as $key)
+        {
+            foreach($this->translations as $language => $files) {
+                if(!$this->keyExistsInTranslations($language, "{$language}.json", $key)) {
+                    $this->translations[$language]["{$language}.json"][$key] = '';
+                }
+            }
+        }
+    }
 
         foreach (array_unique($keysFromFiles) as $fileName => $key) {
             foreach ($translations as $lang => $keys) {
                 if (! array_key_exists($key, $keys)) {
                     $output[] = $key;
+    private function syncGroupKeys($groupKeys)
+    {
+        foreach($groupKeys as $group => $keys) {
+            foreach($this->translations as $language => $files) {
+                foreach($keys as $key) {
+                    if(!$this->keyExistsInTranslations($language, "{$group}.php", $key)) {           
+                        $this->translations[$language]["{$group}.php"][$key] = '';
+                    }
                 }
             }
         }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -64,10 +64,10 @@ class Manager
             return $this->translations;
         }
 
+        if(!$this->translations) $this->addLanguage(config('langmanGUI.base_language'));
+
         $this->getJsonTranslations();
         $this->getArrayTranslations();
-
-        if(!$this->translations) $this->addLanguage(config('langmanGUI.base_language'));
 
         return $this->translations;
     }
@@ -135,11 +135,15 @@ class Manager
     {
         $this->backup();
 
-        file_put_contents($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language.json",
-            json_encode((object)[], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
-        );
+        if(!file_exists($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language.json")) {
+            file_put_contents($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language.json",
+                json_encode((object)['Hello World' => 'Hello World'], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
+            );
+        }
 
-        $this->disk->makeDirectory($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language");
+        if(!file_exists($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language")) {
+            $this->disk->makeDirectory($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language");
+        }   
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -184,23 +184,36 @@ class Manager
 
         $pattern =
             // See https://regex101.com/r/jS5fX0/5
-            '[^\w]' . // Must not start with any alphanum or _
-            '(?<!->)' . // Must not start with ->
-            '(' . implode('|', $functions) . ')' .// Must start with one of the functions
-            "\(\s?" .// Match opening parentheses with optional space character
-            "[\'\"]" .// Match " or '
-            '(' .// Start a new group to match:
-            '.+' .// Must start with group
-            ')' .// Close group
-            "[\'\"]?" .// Closing quote
-            "[\s\),]"  // Close parentheses optional space character or new parameter
+            '[^\w]'. // Must not start with any alphanum or _
+            '(?<!->)'. // Must not start with ->
+            '('.implode('|', $functions).')'.// Must start with one of the functions
+            "\(".// Match opening parentheses
+            "[\'\"]".// Match " or '
+            '('.// Start a new group to match:
+            '.+'.// Must start with group
+            ')'.// Close group
+            "[\'\"]".// Closing quote
+            "[\),]"  // Close parentheses or new parameter
         ;
 
         $allMatches = [];
 
         foreach ($this->disk->allFiles($this->lookupPaths) as $file) {
             if (preg_match_all("/$pattern/siU", $file->getContents(), $matches)) {
-                $allMatches[$file->getRelativePathname()] = $matches[2];
+
+                foreach ($matches[2] as $key) {
+                    if (preg_match("/(^[a-zA-Z0-9_-]+([.][^\1)\ ]+)+$)/siU", $key, $groupMatches)) {
+                        
+                        list($group, $item) = explode('.', $groupMatches[0], 2);
+                        $allMatches['groups'][$group][] = $item;
+                        continue;
+
+                    } else {
+
+                        $allMatches['strings'][] = $key;
+
+                    }
+                }
             }
         }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -133,9 +133,11 @@ class Manager
     {
         $this->backup();
 
-        file_put_contents($this->languageFilesPath.DIRECTORY_SEPARATOR."$language.json",
-            json_encode((object) [], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
+        file_put_contents($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language.json",
+            json_encode((object)[], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
         );
+
+        $this->disk->makeDirectory($this->languageFilesPath . DIRECTORY_SEPARATOR . "$language");
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -64,14 +64,7 @@ class Manager
             return $this->translations;
         }
 
-        collect($this->disk->allFiles($this->languageFilesPath))
-            ->filter(function ($file) {
-                return $this->disk->extension($file) == 'json';
-            })
-            ->each(function ($file) {
-                $this->translations[str_replace('.json', '', $file->getFilename())]
-                    = json_decode($file->getContents());
-            });
+        $this->getJsonTranslations();
 
         return $this->translations;
     }
@@ -185,5 +178,24 @@ class Manager
         }
 
         $this->disk->copyDirectory(resource_path('lang'), storage_path('langmanGUI/'.time()));
+    public function getJsonTranslations()
+    {
+        collect($this->disk->allFiles($this->languageFilesPath))
+            ->filter(function ($file) {
+                return $this->disk->extension($file) == 'json';
+            })
+            ->each(function ($file) {
+                $translations = json_decode($file->getContents(), true);
+                $this->addTranslations(str_replace('.json', '', $file->getFilename()), $file->getFilename(), $translations ?: []);
+            });
+    }
+    /**
+     * @param $language
+     * @param $filename
+     * @param array $translations
+     */
+    private function addTranslations($language, $filename, array $translations)
+    {
+        isset($this->translations[$language][$filename]) ? $this->translations[$language][$filename] += $translations : $this->translations[$language][$filename] = $translations;
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -80,10 +80,14 @@ class Manager
     public function sync()
     {
         $this->backup();
+        $this->getTranslations();
+        $keysFromFiles = $this->getTranslationsFromFiles();
 
-        $output = [];
+        if(isset($keysFromFiles['strings'])) $this->syncStringKeys($keysFromFiles['strings']);
+        if(isset($keysFromFiles['groups'])) $this->syncGroupKeys($keysFromFiles['groups']);
 
-        $translations = $this->getTranslations();
+        return $this->translations;
+    }
 
         $keysFromFiles = array_collapse($this->getTranslationsFromFiles());
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -2,11 +2,11 @@
 
 namespace Themsaid\LangmanGUI;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class Manager
 {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -101,10 +101,6 @@ class Manager
         }
     }
 
-        foreach (array_unique($keysFromFiles) as $fileName => $key) {
-            foreach ($translations as $lang => $keys) {
-                if (! array_key_exists($key, $keys)) {
-                    $output[] = $key;
     private function syncGroupKeys($groupKeys)
     {
         foreach($groupKeys as $group => $keys) {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -67,6 +67,8 @@ class Manager
         $this->getJsonTranslations();
         $this->getArrayTranslations();
 
+        if(!$this->translations) $this->addLanguage(config('langmanGUI.base_language'));
+
         return $this->translations;
     }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -116,8 +116,16 @@ class Manager
                 }
             }
         }
+    }
 
-        return array_values(array_unique($output));
+    private function filenameExistsInTranslations($language, $filename)
+    {
+        return isset($this->translations[$language][$filename]);
+    }
+
+    private function keyExistsInTranslations($language, $filename, $key)
+    {
+        return $this->filenameExistsInTranslations($language, $filename) && array_key_exists($key, $this->translations[$language][$filename]);
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -254,4 +254,14 @@ class Manager
     {
         isset($this->translations[$language][$filename]) ? $this->translations[$language][$filename] += $translations : $this->translations[$language][$filename] = $translations;
     }
+
+    private function convertNullToEmptyString(array $lines)
+    {
+        foreach($lines as $key => $value)
+        {
+            $lines[$key] = is_null($value) ? '' : $value;
+        }
+
+        return $lines;
+    }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -65,6 +65,7 @@ class Manager
         }
 
         $this->getJsonTranslations();
+        $this->getArrayTranslations();
 
         return $this->translations;
     }
@@ -189,6 +190,19 @@ class Manager
                 $this->addTranslations(str_replace('.json', '', $file->getFilename()), $file->getFilename(), $translations ?: []);
             });
     }
+
+    public function getArrayTranslations()
+    {
+        collect($this->disk->allFiles($this->languageFilesPath))
+            ->filter(function ($file) {
+                return $this->disk->extension($file) == 'php';
+            })
+            ->each(function ($file) {
+                $translations = $this->disk->getRequire($file->getPathname());
+                $this->addTranslations($file->getRelativePath(), $file->getFilename(), $translations ?: []);
+            });
+    }
+
     /**
      * @param $language
      * @param $filename

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -105,12 +105,22 @@ class Manager
     {
         $this->backup();
 
-        foreach ($translations as $lang => $lines) {
-            $filename = $this->languageFilesPath.DIRECTORY_SEPARATOR."$lang.json";
+        foreach ($translations as $lang => $file) {
 
-            ksort($lines);
+            foreach($file as $name => $lines) {
 
-            file_put_contents($filename, json_encode($lines, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+                if(is_array($lines)) ksort($lines);
+
+                if(strpos($name, '.json') !== false) {
+                    file_put_contents($this->languageFilesPath . DIRECTORY_SEPARATOR . "$name", json_encode($lines, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+                }
+
+                if(strpos($name, '.php') !== false) {
+                    file_put_contents($this->languageFilesPath . DIRECTORY_SEPARATOR . "$lang" . DIRECTORY_SEPARATOR . "$name", "<?php\n\nreturn " . var_export($lines, true) . ";".\PHP_EOL);
+                }
+
+            }
+            
         }
     }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -137,6 +137,8 @@ class Manager
 
             foreach($file as $name => $lines) {
 
+                $lines = $this->convertNullToEmptyString($lines);
+
                 if(is_array($lines)) ksort($lines);
 
                 if(strpos($name, '.json') !== false) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = function (env) {
             new ExtractTextPlugin("public/langman.css"),
 
             new WebpackOnBuildPlugin(function (stats) {
-                cpy(['public/*'], './../' + env.project + '/public/vendor/langman/').then(() => {
+                cpy(['public/*'], './../../../public/vendor/langman/').then(() => {
                     notifier.notify({
                         'title': 'Build Done',
                         'message': 'Files were copied to public!'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = function (env) {
             new ExtractTextPlugin("public/langman.css"),
 
             new WebpackOnBuildPlugin(function (stats) {
-                cpy(['public/*'], './../../../public/vendor/langman/').then(() => {
+                cpy(['public/*'], './../' + env.project + '/public/vendor/langman/').then(() => {
                     notifier.notify({
                         'title': 'Build Done',
                         'message': 'Files were copied to public!'


### PR DESCRIPTION
This PR adds support for the array style languages files which should resolve #17 

In order to facilitate this, I've added a new dropdown item to the nav which lists all of the files for the selected language. Selecting any filename will filter the keys available for translation.

If the value of a line in the array language file is an array, a textarea is rendered for each of the keys in that array. This will only work one level deep.

![screen shot 2017-10-09 at 14 08 56](https://user-images.githubusercontent.com/3438564/31339661-7dc96602-acfb-11e7-88fa-585b1724ecad.png)

As part of this update, a default language file is created if none already exists with sample translation. This should fix #27 



