### PR TITLE
Support placeholder highlighting

### DIFF
--- a/public/langman.js
+++ b/public/langman.js
@@ -43443,6 +43443,10 @@ new Vue({
                     this.translations[this.baseLanguage][key] = key;
                 }
             });
+        },
+
+        highlight(value) {
+            return value.replace(/:{1}\w+/gi, function (match){return '<mark>' + match +'</mark>';});
         }
     }
 });

--- a/public/langman.js
+++ b/public/langman.js
@@ -43446,7 +43446,7 @@ new Vue({
         },
 
         highlight(value) {
-            return value.replace(/:{1}\w+/gi, function (match){return '<mark>' + match +'</mark>';});
+            return value.replace(/:{1}[\w-]+/gi, function (match){return '<mark>' + match +'</mark>';});
         }
     }
 });

--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -193,7 +193,7 @@ new Vue({
         },
 
         highlight(value) {
-            return value.replace(/:{1}\w+/gi, function (match){return '<mark>' + match +'</mark>';});
+            return value.replace(/:{1}[\w-]+/gi, function (match){return '<mark>' + match +'</mark>';});
         }
     }
 });

--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -190,6 +190,10 @@ new Vue({
                     this.translations[this.baseLanguage][key] = key;
                 }
             });
+        },
+
+        highlight(value) {
+            return value.replace(/:{1}\w+/gi, function (match){return '<mark>' + match +'</mark>';});
         }
     }
 });

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -73,9 +73,9 @@
                            v-on:click="selectedKey = line.key"
                            :class="['list-group-item', 'list-group-item-action', {'list-group-item-danger': !line.value}]">
                             <div class="d-flex w-100 justify-content-between">
-                                <strong class="mb-1">@{{ line.key }}</strong>
+                                <strong class="mb-1" v-html="highlight(line.key)"></strong>
                             </div>
-                            <small class="text-muted">@{{ line.value }}</small>
+                            <small class="text-muted" v-html="highlight(line.value)"></small>
                         </a>
 
                     </div>
@@ -83,9 +83,7 @@
             </div>
             <div class="col">
                 <div v-if="selectedKey">
-                    <p class="mb-4">
-                        @{{ selectedKey }}
-                    </p>
+                    <p class="mb-4" v-html="highlight(selectedKey)"></p>
 
                 <textarea name="" rows="10" class="form-control mb-4"
                           v-model="translations[selectedLanguage][selectedKey]"


### PR DESCRIPTION
This resolves #10 

It will match anything beginning with `:` followed by a-z, A-Z, 0-9, _, - which should cover most eventualities.

![screen shot 2017-10-11 at 14 56 36](https://user-images.githubusercontent.com/3438564/31444666-c230b0da-ae94-11e7-92fd-c989ee31b4f9.png)
