### PR TITLE
Fixes scan of keys translations

### DIFF
--- a/resources/js/langman.js
+++ b/resources/js/langman.js
@@ -80,11 +80,11 @@ new Vue({
          * Add a new translation key
          */
         addNewKey(key) {
-            if (this.translations[this.baseLanguage][key] !== undefined) {
-                return alert('This key already exists.');
-            }
-
             _.forEach(this.languages, lang => {
+                if (this.translations[lang][key] !== undefined) {
+                    return;
+                }
+
                 if (!this.translations[lang]) {
                     this.translations[lang] = {};
                 }
@@ -94,7 +94,6 @@ new Vue({
 
             this.addValuesToBaseLanguage();
         },
-
 
         /**
          * Remove the given key from all languages.


### PR DESCRIPTION
This PR addresses a problem when we are trying to add missing translations to different languages.

Previously, if the translation `__('Dive')` is present on the EN language file, but not present on the FR language file, the button `scan` will not add the `dive` translation into the FR table, since it is was already present on the baseLanguage that is the EN.